### PR TITLE
Adds WORKDIR command inside Dockerfiles

### DIFF
--- a/Dockerfile.bionic
+++ b/Dockerfile.bionic
@@ -13,5 +13,7 @@ RUN set -ex; \
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 
+WORKDIR /usr/share/bcc/tools
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/bin/bash"]

--- a/Dockerfile.trusty
+++ b/Dockerfile.trusty
@@ -13,5 +13,7 @@ RUN set -ex; \
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 
+WORKDIR /usr/share/bcc/tools
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/bin/bash"]

--- a/Dockerfile.xenial
+++ b/Dockerfile.xenial
@@ -13,5 +13,7 @@ RUN set -ex; \
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 
+WORKDIR /usr/share/bcc/tools
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/bin/bash"]

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ push.${1}:
 
 .PHONY: run.${1}
 run.${1}:
-	docker run -it --rm $(DOCKER_CAPS) $(DOCKER_VOLUMES) --workdir /usr/share/bcc/ $(REPO):${1}
+	docker run -it --rm $(DOCKER_CAPS) $(DOCKER_VOLUMES) $(REPO):${1}
 endef #ADD_TARGET
 
 .PHONY: build push

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ docker run -it --rm \
   -v /lib/modules:/lib/modules:ro \
   -v /usr/src:/usr/src:ro \
   -v /etc/localtime:/etc/localtime:ro \
-  --workdir /usr/share/bcc/tools \
   zlim/bcc
 ```
 


### PR DESCRIPTION
Hi, folks.

This Pull Request reduces the number of command line arguments needed to be
passed when getting started with this project/container.

It is a small contribution by adding `WORKDIR` inside Dockerfiles. If an user wants
to make a specific directory as the work directory he can still do it by using `--workdir`
that overrides the `WORKDIR` from inside the `Dockerfile`.

Thanks for this project!